### PR TITLE
Fix pcsc-lite communication with pcscd

### DIFF
--- a/.github/workflows/before-script-linux.sh
+++ b/.github/workflows/before-script-linux.sh
@@ -16,14 +16,14 @@ if [ -f /usr/bin/yum ]; then
 
     cd /tmp && \
     curl --fail -sSL -O https://ftp.gnu.org/gnu/gmp/gmp-${GMP_VERSION}.tar.bz2 && \
-    tar xvf gmp-${GMP_VERSION}.tar.bz2 && \
+    tar xf gmp-${GMP_VERSION}.tar.bz2 && \
     cd gmp-${GMP_VERSION} && \
     ./configure --prefix=$PREFIX && \
     make && make install
 
     cd /tmp &&
     curl --fail -sSL -O https://ftp.gnu.org/gnu/nettle/nettle-${NETTLE_VERSION}.tar.gz && \
-    tar xvf nettle-${NETTLE_VERSION}.tar.gz && \
+    tar xf nettle-${NETTLE_VERSION}.tar.gz && \
     cd nettle-${NETTLE_VERSION} && \
     ./configure --prefix=$PREFIX \
       --with-lib-path=$PREFIX/lib \

--- a/.github/workflows/before-script-linux.sh
+++ b/.github/workflows/before-script-linux.sh
@@ -3,16 +3,37 @@
 set -euxo pipefail
 
 if [ -f /usr/bin/yum ]; then
-    yum install -y openssl-devel pcsc-lite-devel centos-release-scl llvm-toolset-7
+    echo Manylinux2010 build
+
+    yum install -y centos-release-scl llvm-toolset-7 flex
 
     source /opt/rh/llvm-toolset-7/enable
 
     PREFIX=/
+
     # Need to download from mirror because of: https://www.theregister.com/2023/06/28/microsofts_github_gmp_project/
     # See: https://ftp.gnu.org/gnu/gmp/
     GMP_VERSION=6.3.0
+
     # See: https://ftp.gnu.org/gnu/nettle/
     NETTLE_VERSION=3.9.1
+
+    # See: https://pcsclite.apdu.fr/files/
+    PCSCLITE_VERSION=2.0.1
+
+    cd /tmp &&
+    curl --fail -sSL -O https://pcsclite.apdu.fr/files/pcsc-lite-${PCSCLITE_VERSION}.tar.bz2 && \
+    tar xf pcsc-lite-${PCSCLITE_VERSION}.tar.bz2 && \
+    cd pcsc-lite-${PCSCLITE_VERSION} && \
+    ./configure --prefix=$PREFIX \
+      --disable-libsystemd \
+      --disable-libudev \
+      --disable-libusb \
+      --disable-polkit \
+      --enable-filter \
+      --enable-ipcdir=/run/pcscd \
+      --enable-usbdropdir=/usr/lib/pcsc/drivers && \
+    make && make install
 
     cd /tmp && \
     curl --fail -sSL -O https://ftp.gnu.org/gnu/gmp/gmp-${GMP_VERSION}.tar.bz2 && \
@@ -30,8 +51,9 @@ if [ -f /usr/bin/yum ]; then
       --with-include-path=$PREFIX/include \
       --disable-openssl && \
     make && make install
+
 else
-    # Note that this config is NOT used at the moment and can be severely broken
-    apt-get update
-    apt-get install -yqq cargo clang git nettle-dev pkg-config libssl-dev openssl libpcsclite-dev llvm gcc-multilib libgmp-dev libgmp3-dev
+    echo Manylinux2020 build
+    sudo apt-get update
+    sudo apt-get install -yqq cargo clang git nettle-dev pkg-config libssl-dev openssl libpcsclite-dev llvm gcc-multilib libgmp-dev libgmp3-dev
 fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,11 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   e2e:

--- a/.github/workflows/maturin.yml
+++ b/.github/workflows/maturin.yml
@@ -34,7 +34,7 @@ jobs:
           args: --release --out dist --find-interpreter
           manylinux: auto
           before-script-linux: .github/workflows/before-script-linux.sh
-          docker-options: -e LIBCLANG_PATH=/opt/rh/llvm-toolset-7/root/usr/lib64/ -e LIBCLANG_STATIC_PATH=/opt/rh/llvm-toolset-7/root/usr/lib64/ -e CLANG_PATH=/opt/rh/llvm-toolset-7/root/usr/bin/clang
+          docker-options: -e LIBCLANG_PATH=/opt/rh/llvm-toolset-7/root/usr/lib64/ -e LIBCLANG_STATIC_PATH=/opt/rh/llvm-toolset-7/root/usr/lib64/ -e CLANG_PATH=/opt/rh/llvm-toolset-7/root/usr/bin/clang -e PCSC_LIB_DIR=/lib
       - name: Upload wheels
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/maturin.yml
+++ b/.github/workflows/maturin.yml
@@ -1,6 +1,17 @@
 name: Maturin
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  pull_request:
+  workflow_dispatch:
+  push:
+    branches-ignore:
+      - '*'
+    tags:
+      - 'v*'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,6 +1,11 @@
 name: Nix
 
-on: [push, pull_request]
+on:
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   check-and-build:


### PR DESCRIPTION
Due to the build using manylinux container which is super-old the pcsclite client couldn't communicate with pcscd on newer systems.

This is a variant of the following bug: https://blog.apdu.fr/posts/2022/02/accessing-smart-cards-from-inside/

This PR improves the support by building a newer version of pcsc-lite. This should not affect packaged versions, only these distributed on pypi.