### PR TITLE
Release version 0.1.27

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1323,7 +1323,7 @@ dependencies = [
 
 [[package]]
 name = "pysequoia"
-version = "0.1.26"
+version = "0.1.27"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pysequoia"
-version = "0.1.26"
+version = "0.1.27"
 edition = "2021"
 description = "Python bindings for Sequoia PGP"
 homepage = "https://github.com/wiktor-k/pysequoia"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "pysequoia"
-version = "0.1.26"
+version = "0.1.27"
 requires-python = ">=3.7"
 classifiers = [
     "License :: OSI Approved :: Apache Software License",


### PR DESCRIPTION
This version switches the backend to `sequoia-openpgp v2`. There are no functional differences.