### PR TITLE
Add `signature` and `file` parameters to `verify` for detached signatures verification

### DIFF
--- a/NEXT.md
+++ b/NEXT.md
@@ -3,9 +3,11 @@
 v0.1.26
 
 New:
+  - `verify` can be used to verify detached signatures through the new `signature` keyword parameter([#42])
 
 Changed:
 
 Removed:
 
+[#42]: https://github.com/wiktor-k/pysequoia/issues/42
 ### git tag --edit -s -F NEXT.md v...

--- a/NEXT.md
+++ b/NEXT.md
@@ -4,6 +4,7 @@ v0.1.26
 
 New:
   - `verify` can be used to verify detached signatures through the new `signature` keyword parameter([#42])
+  - `verify` accepts a `file` parameter for direct verification of files
 
 Changed:
 

--- a/README.md
+++ b/README.md
@@ -120,11 +120,30 @@ Detached signatures can be verified by passing additional parameter with the det
 data = "data to be signed".encode("utf8")
 detached = sign(s.secrets.signer(), data, mode=SignatureMode.DETACHED)
 
-result = verify(data, get_certs, signature=detached)
+result = verify(bytes=data, store=get_certs, signature=detached)
 
 # let's check the valid signature's certificate and signing subkey fingerprints
 assert result.valid_sigs[0].certificate == "afcf5405e8f49dbcd5dc548a86375b854b86acf9"
 assert result.valid_sigs[0].signing_key == "afcf5405e8f49dbcd5dc548a86375b854b86acf9"
+```
+
+This function can also work with files directly, which is beneficial if the file to be verified is large:
+
+```python
+import tempfile
+with tempfile.NamedTemporaryFile(delete=False) as tmp:
+  data = "data to be signed".encode("utf8")
+  detached = sign(s.secrets.signer(), data, mode=SignatureMode.DETACHED)
+
+  tmp.write(data)
+  tmp.close()
+
+  # verify a detached signature against a file name
+  result = verify(file=tmp.name, store=get_certs, signature=detached)
+
+  # let's check the valid signature's certificate and signing subkey fingerprints
+  assert result.valid_sigs[0].certificate == "afcf5405e8f49dbcd5dc548a86375b854b86acf9"
+  assert result.valid_sigs[0].signing_key == "afcf5405e8f49dbcd5dc548a86375b854b86acf9"
 ```
 
 `verify` succeeds if *at least one* correct signature has been made by any of the certificates supplied. If you need more advanced policies they can be implemented by inspecting the `valid_sigs` property.

--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ PySequoia can be installed through `pip`:
 pip install pysequoia
 ```
 
-Note that since `pysequoia` is implemented largely in Rust, a [Rust
-toolchain][RUSTUP] is necessary for the installation to succeed.
+PyPI version of PySequoia includes native wheels for a variety of architectures and OS combinations.
+If you are using a combination that is not yet provided a [Rust toolchain][RUSTUP] will be necessary for the installation to succeed.
 
 [RUSTUP]: https://rustup.rs/
 

--- a/README.md
+++ b/README.md
@@ -114,6 +114,19 @@ assert result.valid_sigs[0].signing_key == "afcf5405e8f49dbcd5dc548a86375b854b86
 
 The function that returns certificates (here `get_certs`) may return more certificates than necessary.
 
+Detached signatures can be verified by passing additional parameter with the detached signature:
+
+```python
+data = "data to be signed".encode("utf8")
+detached = sign(s.secrets.signer(), data, mode=SignatureMode.DETACHED)
+
+result = verify(data, get_certs, signature=detached)
+
+# let's check the valid signature's certificate and signing subkey fingerprints
+assert result.valid_sigs[0].certificate == "afcf5405e8f49dbcd5dc548a86375b854b86acf9"
+assert result.valid_sigs[0].signing_key == "afcf5405e8f49dbcd5dc548a86375b854b86acf9"
+```
+
 `verify` succeeds if *at least one* correct signature has been made by any of the certificates supplied. If you need more advanced policies they can be implemented by inspecting the `valid_sigs` property.
 
 ### encrypt

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ gpg --batch --pinentry-mode loopback --passphrase '' --export-secret-key no-pass
 All examples assume that these basic classes have been imported:
 
 ```python
-from pysequoia import Cert
+from pysequoia import Cert, Sig
 ```
 
 ### sign
@@ -119,6 +119,7 @@ Detached signatures can be verified by passing additional parameter with the det
 ```python
 data = "data to be signed".encode("utf8")
 detached = sign(s.secrets.signer(), data, mode=SignatureMode.DETACHED)
+detached = Sig.from_bytes(detached)
 
 result = verify(bytes=data, store=get_certs, signature=detached)
 
@@ -134,6 +135,7 @@ import tempfile
 with tempfile.NamedTemporaryFile(delete=False) as tmp:
   data = "data to be signed".encode("utf8")
   detached = sign(s.secrets.signer(), data, mode=SignatureMode.DETACHED)
+  detached = Sig.from_bytes(detached)
 
   tmp.write(data)
   tmp.close()

--- a/src/decrypt.rs
+++ b/src/decrypt.rs
@@ -58,7 +58,7 @@ pub fn decrypt(
     std::io::copy(&mut decryptor, &mut sink)?;
     let decryptor = decryptor.into_helper();
     Ok(Decrypted {
-        content: sink,
+        content: Some(sink),
         valid_sigs: decryptor.valid_sigs(),
     })
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,14 +72,16 @@ impl ValidSig {
 #[derive(Clone)]
 pub struct Decrypted {
     valid_sigs: Vec<ValidSig>,
-    content: Vec<u8>,
+    content: Option<Vec<u8>>,
 }
 
 #[pymethods]
 impl Decrypted {
     #[getter]
-    pub fn bytes(&self) -> Cow<[u8]> {
-        Cow::Borrowed(&self.content)
+    pub fn bytes(&self) -> Option<Cow<[u8]>> {
+        self.content
+            .as_ref()
+            .map(|content| Cow::Borrowed(&content[..]))
     }
 
     #[getter]

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -57,7 +57,7 @@ impl Sig {
         self.sig
             .issuer_fingerprints()
             .next()
-            .map(|issuer| format!("{:x}", issuer))
+            .map(|issuer| format!("{issuer:x}"))
     }
 
     #[getter]

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -64,7 +64,7 @@ impl VerificationHelper for PyVerifier {
         let result: Vec<crate::cert::Cert> = Python::with_gil(|py| {
             let str_ids = ids
                 .iter()
-                .map(|key_id| format!("{:x}", key_id))
+                .map(|key_id| format!("{key_id:x}"))
                 .collect::<Vec<_>>();
             self.store.call1(py, (str_ids,))?.extract(py)
         })?;


### PR DESCRIPTION
This PR adds two parameters to `verify` that can be used interchangeably:
  - `signature` - for holding a detached signature, when this is given the `bytes` parameter is considered raw data for verification (instead of an OpenPGP message).
  - `file` - used instead of `bytes` for passing file name. This is especially useful for large files that would have to be loaded in memory when using `bytes`.

Fixes: https://github.com/wiktor-k/pysequoia/issues/42