### PR TITLE
Overly-strict message structure validation rejects valid signatures

### DIFF
--- a/NEXT.md
+++ b/NEXT.md
@@ -9,11 +9,15 @@ New:
 Changed:
   - `Cert.generate` has a new option to control expiration: `validity_seconds` [#75]
 
+Fixed:
+  - `verify()` is now less prescriptive about OpenPGP message structures and should successfully verify any valid signature. [#76]
+
 Removed:
-  - 
+  -
 
 [#73]: https://github.com/wiktor-k/pysequoia/pull/73
 [#75]: https://github.com/wiktor-k/pysequoia/pull/75
+[#76]: https://github.com/wiktor-k/pysequoia/pull/76
 
 ### Release checklist:
 ###  [ ] Change version in `Cargo.toml` and `pyproject.toml` and `NEXT.md`

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -128,16 +128,9 @@ impl VerificationHelper for PyVerifier {
 
     fn check(&mut self, structure: MessageStructure) -> sequoia_openpgp::Result<()> {
         let mut valid_sigs = vec![];
-        for (i, layer) in structure.into_iter().enumerate() {
-            match layer {
-                MessageLayer::Encryption { .. } if i == 0 => (),
-                MessageLayer::Compression { .. } if i == 1 => (),
-                MessageLayer::SignatureGroup { results } if (0..2).contains(&i) => {
-                    for result in results.into_iter().flatten() {
-                        valid_sigs.push(result.into());
-                    }
-                }
-                _ => return Err(anyhow::anyhow!("Unexpected message structure")),
+        for layer in structure.into_iter() {
+            if let MessageLayer::SignatureGroup { results } = layer {
+                valid_sigs.extend(results.into_iter().flatten().map(Into::into));
             }
         }
 


### PR DESCRIPTION
VerificationHelper is described by the sequoia docs as a way to help users enforce a specific policy without the library itself prescribing one. PySeqoia uses this API to collect valid signatures, but it uses an implementation based on the upstream-provided example which does prescribe a specific structure and is not necessarily general-purpose.
    
This rejects valid message structures e.g. Compressed(Signed(Literal)) which are legal per RFC. e.g. container image signatures generated by `skopeo standalone-sign` omit the encryption because there is no reason to hide the signed image manifest JSON metadata. 
    
As a library, it's probably not useful to be policing message compositions here, when really it's just being used to collect the signatures which have already been verified by Sequoia.