### PR TITLE
Support Post Quantum Cryptography

### DIFF
--- a/.justfile
+++ b/.justfile
@@ -100,7 +100,7 @@ test:
     uv venv .venv
     # shellcheck disable=SC1091
     source .venv/bin/activate
-    maturin develop --release
+    maturin develop
     if [ "${CI:-}" = "true" ]; then
         mkdir -p target/pytest
         uv run --group test -- pytest --junit-xml=target/pytest/junit.xml tests/

--- a/.justfile
+++ b/.justfile
@@ -100,7 +100,7 @@ test:
     uv venv .venv
     # shellcheck disable=SC1091
     source .venv/bin/activate
-    maturin develop
+    maturin develop --release
     if [ "${CI:-}" = "true" ]; then
         mkdir -p target/pytest
         uv run --group test -- pytest --junit-xml=target/pytest/junit.xml tests/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -294,9 +294,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.4.2"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d262e149917187838d5b42777c8253bcb64500067342904e7d429499a6f277e"
+checksum = "509591b7bcd67f4ef775afad7662703b4935daaa6ec0e5605cfb1090b32a2b6d"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -746,9 +746,9 @@ checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b73573e6edcd2af0cdf47bd6cb58f0b3839491263c314eaad1ccf24430e1de"
+checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
 
 [[package]]
 name = "fixedbitset"
@@ -815,9 +815,9 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "1.4.4"
+version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab4e5aa225bc56696909483320f0ff9b600f1a971b52e07a17d70f3d9b43254b"
+checksum = "337d46834ee672ab3e48caca2cb0c78cc174fb12b3a68d0d88f99a0519a5e36e"
 dependencies = [
  "rustversion",
  "typenum",
@@ -965,9 +965,9 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+checksum = "fa68d21081c4a05d5a901a1c62add574c77048b6a1c67be3b50ce0b60d4ca513"
 dependencies = [
  "displaydoc",
  "potential_utf",
@@ -979,9 +979,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+checksum = "d56e28588da92eee5c3201a6eff33fabdd49b62269c8938d4ff050ce4d900deb"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -992,9 +992,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+checksum = "12f9cf5f235641ed274641dd81c3f28d870e276763d0797aeeab72317b1c646f"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -1006,16 +1006,17 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+checksum = "1563da1ed3e0b3bf3d74c9b85917ac9c56464d2f57242270c09c9e752f8021a0"
 
 [[package]]
 name = "icu_properties"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+checksum = "7e7ca276ad3145661a65914e6daf131ca5120cd3dcee8f8f3214b8875184a148"
 dependencies = [
+ "displaydoc",
  "icu_collections",
  "icu_locale_core",
  "icu_properties_data",
@@ -1026,15 +1027,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+checksum = "e590f038c1464a96894fd6d10127e90a8be4509f56ff7ecef851b15cee0b7caa"
 
 [[package]]
 name = "icu_provider"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+checksum = "92a7ed671a6aad807a8651a2e1782a6598fda9ce5185dd8158549e95a91c6428"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -1209,9 +1210,9 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "litemap"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+checksum = "47d9d19d1d6efa0109d2f65ff4c85cddd50bd572e5a00127ab10987290bcefae"
 
 [[package]]
 name = "lock_api"
@@ -1536,9 +1537,9 @@ checksum = "05c8b63e8d9609db387f0324918f81d68fe27748f084ef092fb35954d0539a85"
 
 [[package]]
 name = "potential_utf"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+checksum = "d83eb9bc6d8e5cf568e7a1101d60ee05e81ed50ea106026f3d18deeb046d7661"
 dependencies = [
  "zerovec",
 ]
@@ -2006,7 +2007,7 @@ checksum = "1f606421e4a6012877e893c399822a4ed4b089164c5969424e1b9d1e66e6964b"
 dependencies = [
  "const-oid",
  "digest 0.10.7",
- "generic-array 1.4.4",
+ "generic-array 1.4.5",
 ]
 
 [[package]]
@@ -2253,9 +2254,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+checksum = "b1e27c91459209c2986af3dcf603a5a74a4368754ce37414f59acc971167f643"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -2471,9 +2472,9 @@ checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "writeable"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+checksum = "3ad82d2a33cdc9674dc7465672f271e096168fcdbe0f799d9e6db8c5892679dc"
 
 [[package]]
 name = "wyz"
@@ -2617,9 +2618,9 @@ dependencies = [
 
 [[package]]
 name = "zerotrie"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+checksum = "4ea269c3bd32f0a32c321907a2ae912ba6f4649bb0fc764a15627e99a7095a3f"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -2628,9 +2629,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.6"
+version = "0.11.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+checksum = "94b5c6b5976d66c1d703c4fd17d3f5e43c8cedaacf604961b171adc7130896d8"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -2639,13 +2640,13 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.3"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+checksum = "47402523226a02bfe5230160dc3ccc089aa6f6f19e7fcbb4e6f824bbb1b4aa62"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,10 +25,10 @@ package.edition = "2024"
 anyhow = "1"
 chrono = "0.4"
 once_cell = "1.21"
-sequoia-openpgp = { version = "2", default-features = false, features = [ "crypto-rust", "allow-experimental-crypto", "allow-variable-time-crypto", "compression-deflate"] }
+sequoia-openpgp = { version = "2.4", default-features = false, features = [ "crypto-rust", "allow-experimental-crypto", "allow-variable-time-crypto", "compression-deflate"] }
 
 [dependencies.pyo3]
-version = "0.29"
+version = "0.29.1"
 # "py-clone" feature added to keep the original behavior but it'd be good to avoid it
 # see: https://github.com/PyO3/pyo3/pull/4095
 features = ["anyhow", "chrono", "py-clone", "experimental-inspect"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,3 +32,6 @@ version = "0.29.1"
 # "py-clone" feature added to keep the original behavior but it'd be good to avoid it
 # see: https://github.com/PyO3/pyo3/pull/4095
 features = ["anyhow", "chrono", "py-clone", "experimental-inspect"]
+
+[profile.dev.package."*"]
+opt-level = 3

--- a/NEXT.md
+++ b/NEXT.md
@@ -7,6 +7,10 @@ New:
   - `verify` now supports compressed signatures [#77]
   - `Cert.generate` has a new option to control expiration: `validity_seconds` [#75]
   - `Packet` now supports `__bytes__` to get the full serialized packet [#85]
+  - Post-quantum cryptography (PQC) support via sequoia-openpgp 2.4:
+    - `PublicKeyAlgorithm` now includes PQC variants (ML-DSA, SLH-DSA, ML-KEM)
+    - New `CipherSuite` enum for `Tsk.generate()` with PQC presets (`MLDSA65_Ed25519`, `MLDSA87_Ed448`)
+    - New `SigningAlgorithm` and `EncryptionAlgorithm` enums for fine-grained algorithm selection (e.g. SLH-DSA signing with classical encryption)
 
 Fixed:
   - `Packet.body` now returns just the body bytes without the tag and length header [#85]
@@ -20,6 +24,7 @@ Removed:
 [#73]: https://github.com/wiktor-k/pysequoia/pull/73
 [#75]: https://github.com/wiktor-k/pysequoia/pull/75
 [#77]: https://github.com/wiktor-k/pysequoia/pull/77
+[#84]: https://github.com/wiktor-k/pysequoia/pull/84
 [#85]: https://github.com/wiktor-k/pysequoia/pull/85
 
 ### Release checklist:

--- a/python/pysequoia/__init__.pyi
+++ b/python/pysequoia/__init__.pyi
@@ -221,6 +221,36 @@ class Decrypted:
         """
 
 @final
+class EncryptionAlgorithm:
+    """
+    The encryption algorithm to use when generating keys.
+
+    Used with `Cert.generate(encryption_algorithm=...)` to override the
+    encryption algorithm independently of the cipher suite. Requires
+    `Profile.RFC9580` for PQC algorithms (except `MLKEM768_X25519`).
+    """
+    MLKEM1024_X448: Final[EncryptionAlgorithm]
+    """
+    Composite ML-KEM-1024 + X448 (post-quantum)
+    """
+    MLKEM768_X25519: Final[EncryptionAlgorithm]
+    """
+    Composite ML-KEM-768 + X25519 (post-quantum)
+    """
+    X25519: Final[EncryptionAlgorithm]
+    """
+    X25519
+    """
+    X448: Final[EncryptionAlgorithm]
+    """
+    X448
+    """
+    def __eq__(self, value: object, /) -> bool: ...
+    def __int__(self, /) -> int: ...
+    def __ne__(self, value: object, /) -> bool: ...
+    def __repr__(self, /) -> str: ...
+
+@final
 class Notation:
     """
     A key-value notation attached to an OpenPGP signature.
@@ -391,6 +421,48 @@ class SignatureMode:
     def __repr__(self, /) -> str: ...
 
 @final
+class SigningAlgorithm:
+    """
+    The signing algorithm to use when generating keys.
+
+    Used with `Cert.generate(signing_algorithm=...)` to override the signing
+    algorithm independently of the cipher suite. Requires `Profile.RFC9580`
+    for PQC algorithms.
+    """
+    Ed25519: Final[SigningAlgorithm]
+    """
+    Ed25519
+    """
+    Ed448: Final[SigningAlgorithm]
+    """
+    Ed448
+    """
+    MLDSA65_Ed25519: Final[SigningAlgorithm]
+    """
+    Composite ML-DSA-65 + Ed25519 (post-quantum)
+    """
+    MLDSA87_Ed448: Final[SigningAlgorithm]
+    """
+    Composite ML-DSA-87 + Ed448 (post-quantum)
+    """
+    SLHDSA128f: Final[SigningAlgorithm]
+    """
+    SLH-DSA 128-bit fast signatures (post-quantum, stateless)
+    """
+    SLHDSA128s: Final[SigningAlgorithm]
+    """
+    SLH-DSA 128-bit small signatures (post-quantum, stateless)
+    """
+    SLHDSA256s: Final[SigningAlgorithm]
+    """
+    SLH-DSA 256-bit small signatures (post-quantum, stateless)
+    """
+    def __eq__(self, value: object, /) -> bool: ...
+    def __int__(self, /) -> int: ...
+    def __ne__(self, value: object, /) -> bool: ...
+    def __repr__(self, /) -> str: ...
+
+@final
 class Tsk:
     """
     A certificate that contains secret key material.
@@ -446,7 +518,7 @@ class Tsk:
         its associated user IDs, user attributes, subkeys, and signatures).
         """
     @staticmethod
-    def generate(user_id: str |None = None, user_ids: Sequence[str] |None = None, profile: Profile |None = None, cipher_suite: CipherSuite |None = None, validity_seconds: int |None = ...) -> Tsk:
+    def generate(user_id: str |None = None, user_ids: Sequence[str] |None = None, profile: Profile |None = None, cipher_suite: CipherSuite |None = None, validity_seconds: int |None = ..., *, signing_algorithm: SigningAlgorithm |None = None, encryption_algorithm: EncryptionAlgorithm |None = None) -> Tsk:
         """
         Generate a new TSK with a certification-capable primary key,
         a signing subkey, and an encryption subkey.

--- a/python/pysequoia/__init__.pyi
+++ b/python/pysequoia/__init__.pyi
@@ -150,6 +150,59 @@ class Cert:
         """
 
 @final
+class CipherSuite:
+    """
+    The cipher suite to use when generating keys.
+
+    Controls which cryptographic algorithms are used for the primary key and subkeys.
+    The PQC (post-quantum cryptography) suites require `Profile.RFC9580`.
+    """
+    Cv25519: Final[CipherSuite]
+    """
+    EdDSA and ECDH over Curve25519 (default)
+    """
+    Cv448: Final[CipherSuite]
+    """
+    EdDSA and ECDH over Curve448
+    """
+    MLDSA65_Ed25519: Final[CipherSuite]
+    """
+    Post-quantum: ML-DSA-65 + Ed25519 signing, ML-KEM-768 + X25519 encryption (v6 only)
+    """
+    MLDSA87_Ed448: Final[CipherSuite]
+    """
+    Post-quantum: ML-DSA-87 + Ed448 signing, ML-KEM-1024 + X448 encryption (v6 only)
+    """
+    P256: Final[CipherSuite]
+    """
+    ECDSA and ECDH over NIST P-256
+    """
+    P384: Final[CipherSuite]
+    """
+    ECDSA and ECDH over NIST P-384
+    """
+    P521: Final[CipherSuite]
+    """
+    ECDSA and ECDH over NIST P-521
+    """
+    RSA2k: Final[CipherSuite]
+    """
+    2048-bit RSA
+    """
+    RSA3k: Final[CipherSuite]
+    """
+    3072-bit RSA
+    """
+    RSA4k: Final[CipherSuite]
+    """
+    4096-bit RSA
+    """
+    def __eq__(self, value: object, /) -> bool: ...
+    def __int__(self, /) -> int: ...
+    def __ne__(self, value: object, /) -> bool: ...
+    def __repr__(self, /) -> str: ...
+
+@final
 class Decrypted:
     """
     The result of a decryption or verification operation.
@@ -393,7 +446,7 @@ class Tsk:
         its associated user IDs, user attributes, subkeys, and signatures).
         """
     @staticmethod
-    def generate(user_id: str |None = None, user_ids: Sequence[str] |None = None, profile: Profile |None = None, validity_seconds: int |None = ...) -> Tsk:
+    def generate(user_id: str |None = None, user_ids: Sequence[str] |None = None, profile: Profile |None = None, cipher_suite: CipherSuite |None = None, validity_seconds: int |None = ...) -> Tsk:
         """
         Generate a new TSK with a certification-capable primary key,
         a signing subkey, and an encryption subkey.

--- a/python/pysequoia/packet.pyi
+++ b/python/pysequoia/packet.pyi
@@ -394,6 +394,22 @@ class PublicKeyAlgorithm:
     """
     ElGamal Encrypt or Sign, deprecated
     """
+    MLDSA65_Ed25519: Final[PublicKeyAlgorithm]
+    """
+    Composite ML-DSA-65 + Ed25519 signing algorithm
+    """
+    MLDSA87_Ed448: Final[PublicKeyAlgorithm]
+    """
+    Composite ML-DSA-87 + Ed448 signing algorithm
+    """
+    MLKEM1024_X448: Final[PublicKeyAlgorithm]
+    """
+    Composite ML-KEM-1024 + X448 encryption algorithm
+    """
+    MLKEM768_X25519: Final[PublicKeyAlgorithm]
+    """
+    Composite ML-KEM-768 + X25519 encryption algorithm
+    """
     RSAEncrypt: Final[PublicKeyAlgorithm]
     """
     RSA Encrypt-Only, deprecated
@@ -405,6 +421,18 @@ class PublicKeyAlgorithm:
     RSASign: Final[PublicKeyAlgorithm]
     """
     RSA Sign-Only, deprecated
+    """
+    SLHDSA128f: Final[PublicKeyAlgorithm]
+    """
+    SLH-DSA 128-bit fast signatures
+    """
+    SLHDSA128s: Final[PublicKeyAlgorithm]
+    """
+    SLH-DSA 128-bit small signatures
+    """
+    SLHDSA256s: Final[PublicKeyAlgorithm]
+    """
+    SLH-DSA 256-bit small signatures
     """
     X25519: Final[PublicKeyAlgorithm]
     """

--- a/src/cert.rs
+++ b/src/cert.rs
@@ -142,7 +142,7 @@ impl Cert {
         profile: Option<Profile>,
         validity_seconds: Option<u64>,
     ) -> PyResult<Self> {
-        let tsk = Tsk::generate(user_id, user_ids, profile, validity_seconds)?;
+        let tsk = Tsk::generate(user_id, user_ids, profile, None, validity_seconds)?;
         tsk.extract_certificate()
     }
 

--- a/src/cert.rs
+++ b/src/cert.rs
@@ -142,7 +142,15 @@ impl Cert {
         profile: Option<Profile>,
         validity_seconds: Option<u64>,
     ) -> PyResult<Self> {
-        let tsk = Tsk::generate(user_id, user_ids, profile, None, validity_seconds)?;
+        let tsk = Tsk::generate(
+            user_id,
+            user_ids,
+            profile,
+            None,
+            validity_seconds,
+            None,
+            None,
+        )?;
         tsk.extract_certificate()
     }
 

--- a/src/cert/secret.rs
+++ b/src/cert/secret.rs
@@ -2,7 +2,6 @@ use std::borrow::Cow;
 use std::sync::{Arc, Mutex, MutexGuard};
 
 use pyo3::prelude::*;
-use sequoia_openpgp::cert::{CertBuilder, CipherSuite};
 use sequoia_openpgp::parse::Parse as _;
 use sequoia_openpgp::types::KeyFlags;
 use sequoia_openpgp::{cert, policy::Policy, serialize::SerializeInto};
@@ -10,6 +9,54 @@ use sequoia_openpgp::{cert, policy::Policy, serialize::SerializeInto};
 use crate::cert::{DEFAULT_POLICY, Profile};
 use crate::decrypt;
 use crate::signer::PySigner;
+
+/// The cipher suite to use when generating keys.
+///
+/// Controls which cryptographic algorithms are used for the primary key and subkeys.
+/// The PQC (post-quantum cryptography) suites require `Profile.RFC9580`.
+#[derive(Clone, Copy, Default, PartialEq, Eq)]
+#[pyclass(from_py_object, eq)]
+#[allow(non_camel_case_types)]
+pub enum CipherSuite {
+    /// EdDSA and ECDH over Curve25519 (default)
+    #[default]
+    Cv25519,
+    /// EdDSA and ECDH over Curve448
+    Cv448,
+    /// 2048-bit RSA
+    RSA2k,
+    /// 3072-bit RSA
+    RSA3k,
+    /// 4096-bit RSA
+    RSA4k,
+    /// ECDSA and ECDH over NIST P-256
+    P256,
+    /// ECDSA and ECDH over NIST P-384
+    P384,
+    /// ECDSA and ECDH over NIST P-521
+    P521,
+    /// Post-quantum: ML-DSA-65 + Ed25519 signing, ML-KEM-768 + X25519 encryption (v6 only)
+    MLDSA65_Ed25519,
+    /// Post-quantum: ML-DSA-87 + Ed448 signing, ML-KEM-1024 + X448 encryption (v6 only)
+    MLDSA87_Ed448,
+}
+
+impl From<CipherSuite> for cert::CipherSuite {
+    fn from(cs: CipherSuite) -> Self {
+        match cs {
+            CipherSuite::Cv25519 => Self::Cv25519,
+            CipherSuite::Cv448 => Self::Cv448,
+            CipherSuite::RSA2k => Self::RSA2k,
+            CipherSuite::RSA3k => Self::RSA3k,
+            CipherSuite::RSA4k => Self::RSA4k,
+            CipherSuite::P256 => Self::P256,
+            CipherSuite::P384 => Self::P384,
+            CipherSuite::P521 => Self::P521,
+            CipherSuite::MLDSA65_Ed25519 => Self::MLDSA65_Ed25519,
+            CipherSuite::MLDSA87_Ed448 => Self::MLDSA87_Ed448,
+        }
+    }
+}
 
 /// A certificate that contains secret key material.
 ///
@@ -49,16 +96,17 @@ impl Tsk {
     ///
     /// The generated certificate has a validity period of 3 years.
     #[staticmethod]
-    #[pyo3(signature = (user_id=None, user_ids=None, profile=None, validity_seconds=3 * 52 * 7 * 24 * 60 * 60))]
+    #[pyo3(signature = (user_id=None, user_ids=None, profile=None, cipher_suite=None, validity_seconds=3 * 52 * 7 * 24 * 60 * 60))]
     pub fn generate(
         user_id: Option<&str>,
         user_ids: Option<Vec<String>>,
         profile: Option<Profile>,
+        cipher_suite: Option<CipherSuite>,
         validity_seconds: Option<u64>,
     ) -> PyResult<Self> {
-        let mut builder = CertBuilder::new()
+        let mut builder = cert::CertBuilder::new()
             .set_profile(profile.unwrap_or_default().into())?
-            .set_cipher_suite(CipherSuite::default())
+            .set_cipher_suite(cipher_suite.unwrap_or_default().into())
             .set_primary_key_flags(KeyFlags::empty().set_certification())
             .add_signing_subkey()
             .add_subkey(

--- a/src/cert/secret.rs
+++ b/src/cert/secret.rs
@@ -96,13 +96,15 @@ impl Tsk {
     ///
     /// The generated certificate has a validity period of 3 years.
     #[staticmethod]
-    #[pyo3(signature = (user_id=None, user_ids=None, profile=None, cipher_suite=None, validity_seconds=3 * 52 * 7 * 24 * 60 * 60))]
+    #[pyo3(signature = (user_id=None, user_ids=None, profile=None, cipher_suite=None, validity_seconds=3 * 52 * 7 * 24 * 60 * 60, *, signing_algorithm=None, encryption_algorithm=None))]
     pub fn generate(
         user_id: Option<&str>,
         user_ids: Option<Vec<String>>,
         profile: Option<Profile>,
         cipher_suite: Option<CipherSuite>,
         validity_seconds: Option<u64>,
+        signing_algorithm: Option<crate::types::SigningAlgorithm>,
+        encryption_algorithm: Option<crate::types::EncryptionAlgorithm>,
     ) -> PyResult<Self> {
         let mut builder = cert::CertBuilder::new()
             .set_profile(profile.unwrap_or_default().into())?
@@ -116,6 +118,12 @@ impl Tsk {
                 None,
                 None,
             );
+        if let Some(signing_algo) = signing_algorithm {
+            builder = builder.set_signing_algorithm(signing_algo.into());
+        }
+        if let Some(encryption_algo) = encryption_algorithm {
+            builder = builder.set_encryption_algorithm(encryption_algo.into());
+        }
         if let Some(validity_seconds) = validity_seconds {
             builder = builder.set_validity_period(std::time::Duration::new(validity_seconds, 0))
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -163,6 +163,10 @@ pub mod pysequoia {
     #[pymodule_export]
     pub use super::types::ArmorKind;
     #[pymodule_export]
+    pub use super::types::EncryptionAlgorithm;
+    #[pymodule_export]
+    pub use super::types::SigningAlgorithm;
+    #[pymodule_export]
     pub use super::user_id::UserId;
     #[pymodule_export]
     pub use super::verify::verify;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,6 +135,8 @@ pub mod pysequoia {
     #[pymodule_export]
     pub use super::cert::Profile;
     #[pymodule_export]
+    pub use super::cert::secret::CipherSuite;
+    #[pymodule_export]
     pub use super::cert::secret::Tsk;
     #[pymodule_export]
     pub use super::decrypt::PyDecryptor;

--- a/src/types.rs
+++ b/src/types.rs
@@ -8,7 +8,9 @@ use pyo3::prelude::*;
 use sequoia_openpgp::packet::Tag as SqTag;
 use sequoia_openpgp::types::{
     DataFormat as SqDataFormat, HashAlgorithm as SqHashAlgorithm, KeyFlags as SqKeyFlags,
-    PublicKeyAlgorithm as SqPublicKeyAlgorithm, SignatureType as SqSignatureType,
+    PublicKeyAlgorithm as SqPublicKeyAlgorithm,
+    PublicKeyAlgorithmSpecification as SqPublicKeyAlgorithmSpecification,
+    SignatureType as SqSignatureType,
 };
 
 /// The type of an OpenPGP signature, as defined in RFC 4880 / 9580.
@@ -79,7 +81,10 @@ impl TryFrom<SqSignatureType> for SignatureType {
 /// The public key algorithm used by an OpenPGP key.
 #[pyclass(eq, skip_from_py_object)]
 #[derive(Clone, Copy, PartialEq, Eq)]
-#[expect(non_camel_case_types, reason = "type names aligned with the specification")]
+#[expect(
+    non_camel_case_types,
+    reason = "type names aligned with the specification"
+)]
 pub enum PublicKeyAlgorithm {
     /// RSA (Encrypt or Sign)
     RSAEncryptSign,
@@ -333,6 +338,78 @@ impl From<ArmorKind> for sequoia_openpgp::armor::Kind {
             ArmorKind::SecretKey => Self::SecretKey,
             ArmorKind::Message => Self::Message,
             ArmorKind::Signature => Self::Signature,
+        }
+    }
+}
+
+/// The signing algorithm to use when generating keys.
+///
+/// Used with `Cert.generate(signing_algorithm=...)` to override the signing
+/// algorithm independently of the cipher suite. Requires `Profile.RFC9580`
+/// for PQC algorithms.
+#[pyclass(from_py_object, eq)]
+#[derive(Clone, PartialEq, Eq)]
+#[expect(
+    non_camel_case_types,
+    reason = "type names aligned with the specification"
+)]
+pub enum SigningAlgorithm {
+    /// Composite ML-DSA-65 + Ed25519 (post-quantum)
+    MLDSA65_Ed25519,
+    /// Composite ML-DSA-87 + Ed448 (post-quantum)
+    MLDSA87_Ed448,
+    /// SLH-DSA 128-bit small signatures (post-quantum, stateless)
+    SLHDSA128s,
+    /// SLH-DSA 128-bit fast signatures (post-quantum, stateless)
+    SLHDSA128f,
+    /// SLH-DSA 256-bit small signatures (post-quantum, stateless)
+    SLHDSA256s,
+    /// Ed25519
+    Ed25519,
+    /// Ed448
+    Ed448,
+}
+
+impl From<SigningAlgorithm> for SqPublicKeyAlgorithmSpecification {
+    fn from(algo: SigningAlgorithm) -> Self {
+        match algo {
+            SigningAlgorithm::MLDSA65_Ed25519 => Self::mldsa65_ed25519(),
+            SigningAlgorithm::MLDSA87_Ed448 => Self::mldsa87_ed448(),
+            SigningAlgorithm::SLHDSA128s => Self::slhdsa128s(),
+            SigningAlgorithm::SLHDSA128f => Self::slhdsa128f(),
+            SigningAlgorithm::SLHDSA256s => Self::slhdsa256s(),
+            SigningAlgorithm::Ed25519 => Self::ed25519(),
+            SigningAlgorithm::Ed448 => Self::ed448(),
+        }
+    }
+}
+
+/// The encryption algorithm to use when generating keys.
+///
+/// Used with `Tsk.generate(encryption_algorithm=...)` to override the
+/// encryption algorithm independently of the cipher suite. Requires
+/// `Profile.RFC9580` for PQC algorithms (except `MLKEM768_X25519`).
+#[pyclass(from_py_object, eq)]
+#[derive(Clone, PartialEq, Eq)]
+#[allow(non_camel_case_types)]
+pub enum EncryptionAlgorithm {
+    /// Composite ML-KEM-768 + X25519 (post-quantum)
+    MLKEM768_X25519,
+    /// Composite ML-KEM-1024 + X448 (post-quantum)
+    MLKEM1024_X448,
+    /// X25519
+    X25519,
+    /// X448
+    X448,
+}
+
+impl From<EncryptionAlgorithm> for SqPublicKeyAlgorithmSpecification {
+    fn from(algo: EncryptionAlgorithm) -> Self {
+        match algo {
+            EncryptionAlgorithm::MLKEM768_X25519 => Self::mlkem768_x25519(),
+            EncryptionAlgorithm::MLKEM1024_X448 => Self::mlkem1024_x448(),
+            EncryptionAlgorithm::X25519 => Self::x25519(),
+            EncryptionAlgorithm::X448 => Self::x448(),
         }
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -79,6 +79,7 @@ impl TryFrom<SqSignatureType> for SignatureType {
 /// The public key algorithm used by an OpenPGP key.
 #[pyclass(eq, skip_from_py_object)]
 #[derive(Clone, Copy, PartialEq, Eq)]
+#[expect(non_camel_case_types, reason = "type names aligned with the specification")]
 pub enum PublicKeyAlgorithm {
     /// RSA (Encrypt or Sign)
     RSAEncryptSign,
@@ -110,6 +111,20 @@ pub enum PublicKeyAlgorithm {
     Ed25519,
     /// Ed448
     Ed448,
+    /// Composite ML-DSA-65 + Ed25519 signing algorithm
+    MLDSA65_Ed25519,
+    /// Composite ML-DSA-87 + Ed448 signing algorithm
+    MLDSA87_Ed448,
+    /// SLH-DSA 128-bit small signatures
+    SLHDSA128s,
+    /// SLH-DSA 128-bit fast signatures
+    SLHDSA128f,
+    /// SLH-DSA 256-bit small signatures
+    SLHDSA256s,
+    /// Composite ML-KEM-768 + X25519 encryption algorithm
+    MLKEM768_X25519,
+    /// Composite ML-KEM-1024 + X448 encryption algorithm
+    MLKEM1024_X448,
 }
 
 impl TryFrom<SqPublicKeyAlgorithm> for PublicKeyAlgorithm {
@@ -130,6 +145,13 @@ impl TryFrom<SqPublicKeyAlgorithm> for PublicKeyAlgorithm {
             SqPublicKeyAlgorithm::X448 => Ok(Self::X448),
             SqPublicKeyAlgorithm::Ed25519 => Ok(Self::Ed25519),
             SqPublicKeyAlgorithm::Ed448 => Ok(Self::Ed448),
+            SqPublicKeyAlgorithm::MLDSA65_Ed25519 => Ok(Self::MLDSA65_Ed25519),
+            SqPublicKeyAlgorithm::MLDSA87_Ed448 => Ok(Self::MLDSA87_Ed448),
+            SqPublicKeyAlgorithm::SLHDSA128s => Ok(Self::SLHDSA128s),
+            SqPublicKeyAlgorithm::SLHDSA128f => Ok(Self::SLHDSA128f),
+            SqPublicKeyAlgorithm::SLHDSA256s => Ok(Self::SLHDSA256s),
+            SqPublicKeyAlgorithm::MLKEM768_X25519 => Ok(Self::MLKEM768_X25519),
+            SqPublicKeyAlgorithm::MLKEM1024_X448 => Ok(Self::MLKEM1024_X448),
             SqPublicKeyAlgorithm::Private(u) => Err(anyhow!("Private public key algorithm: {u}")),
             SqPublicKeyAlgorithm::Unknown(u) => Err(anyhow!("Unknown public key algorithm: {u}")),
             _ => Err(anyhow!(

--- a/tests/test_pysequoia.py
+++ b/tests/test_pysequoia.py
@@ -21,7 +21,7 @@ from pysequoia import (
     sign_file,
     verify,
 )
-from pysequoia.packet import PacketPile, Tag
+from pysequoia.packet import PacketPile, PublicKeyAlgorithm, Tag
 
 FIXTURES = os.path.join(os.path.dirname(__file__), "fixtures")
 
@@ -664,6 +664,25 @@ class TestPasswordProtectedKeys:
         )
         with pytest.raises(Exception):
             decrypt(decryptor=bob.decryptor(), bytes=encrypted)
+
+
+class TestPublicKeyAlgorithm:
+    def test_pqc_algorithm_variants_exist(self):
+        assert PublicKeyAlgorithm.MLDSA65_Ed25519 is not None
+        assert PublicKeyAlgorithm.MLDSA87_Ed448 is not None
+        assert PublicKeyAlgorithm.SLHDSA128s is not None
+        assert PublicKeyAlgorithm.SLHDSA128f is not None
+        assert PublicKeyAlgorithm.SLHDSA256s is not None
+        assert PublicKeyAlgorithm.MLKEM768_X25519 is not None
+        assert PublicKeyAlgorithm.MLKEM1024_X448 is not None
+
+    def test_pqc_and_classical_are_distinct(self):
+        assert PublicKeyAlgorithm.MLDSA65_Ed25519 != PublicKeyAlgorithm.Ed25519
+        assert PublicKeyAlgorithm.MLKEM768_X25519 != PublicKeyAlgorithm.X25519
+
+    def test_pqc_repr(self):
+        assert "MLDSA65_Ed25519" in repr(PublicKeyAlgorithm.MLDSA65_Ed25519)
+        assert "MLKEM768_X25519" in repr(PublicKeyAlgorithm.MLKEM768_X25519)
 
 
 class TestErrorCases:

--- a/tests/test_pysequoia.py
+++ b/tests/test_pysequoia.py
@@ -8,10 +8,12 @@ from pysequoia import (
     ArmorKind,
     Cert,
     CipherSuite,
+    EncryptionAlgorithm,
     Notation,
     Profile,
     Sig,
     SignatureMode,
+    SigningAlgorithm,
     Tsk,
     armor,
     decrypt,
@@ -699,6 +701,82 @@ class TestPQC:
             store=store,
         )
         assert decrypted.bytes == content
+
+
+class TestAlgorithmSelection:
+    def test_slhdsa_signing(self):
+        tsk = Tsk.generate(
+            "SLH <slh@example.com>",
+            profile=Profile.RFC9580,
+            signing_algorithm=SigningAlgorithm.SLHDSA128f,
+        )
+        data = b"slh-dsa signed data"
+        signed = sign(tsk.signer(), data)
+
+        def store(key_ids):
+            return [tsk.extract_certificate()]
+
+        result = verify(signed, store)
+        assert result.bytes == data
+
+    def test_mixed_pqc_encryption_classical_signing(self):
+        tsk = Tsk.generate(
+            "Mixed <mixed@example.com>",
+            profile=Profile.RFC9580,
+            encryption_algorithm=EncryptionAlgorithm.MLKEM768_X25519,
+        )
+        data = b"mixed algorithm message"
+        signed = sign(tsk.signer(), data)
+
+        def store(key_ids):
+            return [tsk.extract_certificate()]
+
+        result = verify(signed, store)
+        assert result.bytes == data
+
+        encrypted = encrypt(recipients=[tsk.extract_certificate()], bytes=data)
+        decrypted = decrypt(decryptor=tsk.decryptor(), bytes=encrypted)
+        assert decrypted.bytes == data
+
+    def test_slhdsa_with_default_encryption(self):
+        tsk = Tsk.generate(
+            "SLH <slh@example.com>",
+            profile=Profile.RFC9580,
+            signing_algorithm=SigningAlgorithm.SLHDSA128s,
+        )
+        pile = PacketPile.from_bytes(bytes(tsk.extract_certificate()))
+        key_algorithms = [
+            p.key_algorithm
+            for p in pile
+            if p.tag in (Tag.PublicKey, Tag.PublicSubkey)
+        ]
+        assert PublicKeyAlgorithm.SLHDSA128s in key_algorithms
+        assert PublicKeyAlgorithm.X25519 in key_algorithms
+
+    def test_slhdsa_detached_sig_version(self):
+        tsk = Tsk.generate(
+            "SLH <slh@example.com>",
+            profile=Profile.RFC9580,
+            signing_algorithm=SigningAlgorithm.SLHDSA128f,
+        )
+        detached = sign(tsk.signer(), b"data", mode=SignatureMode.DETACHED)
+        sig = Sig.from_bytes(detached)
+        assert sig.version == 6
+
+    def test_signing_algorithm_variants_exist(self):
+        assert SigningAlgorithm.MLDSA65_Ed25519 is not None
+        assert SigningAlgorithm.MLDSA87_Ed448 is not None
+        assert SigningAlgorithm.SLHDSA128s is not None
+        assert SigningAlgorithm.SLHDSA128f is not None
+        assert SigningAlgorithm.SLHDSA256s is not None
+        assert SigningAlgorithm.Ed25519 is not None
+        assert SigningAlgorithm.Ed448 is not None
+
+    def test_encryption_algorithm_variants_exist(self):
+        assert EncryptionAlgorithm.MLKEM768_X25519 is not None
+        assert EncryptionAlgorithm.MLKEM1024_X448 is not None
+        assert EncryptionAlgorithm.X25519 is not None
+        assert EncryptionAlgorithm.X448 is not None
 
 
 class TestCipherSuite:

--- a/tests/test_pysequoia.py
+++ b/tests/test_pysequoia.py
@@ -7,6 +7,7 @@ import pytest
 from pysequoia import (
     ArmorKind,
     Cert,
+    CipherSuite,
     Notation,
     Profile,
     Sig,
@@ -566,6 +567,162 @@ class TestRFC9580:
         )
         decrypted = decrypt(decryptor=receiver.decryptor(), bytes=encrypted)
         assert decrypted.bytes == content
+
+
+class TestPQC:
+    def test_generate_pqc_cert(self):
+        tsk = Tsk.generate(
+            "PQC <pqc@example.com>",
+            profile=Profile.RFC9580,
+            cipher_suite=CipherSuite.MLDSA65_Ed25519,
+        )
+        cert = tsk.extract_certificate()
+        assert len(cert.fingerprint) > 0
+        assert str(cert.user_ids[0]) == "PQC <pqc@example.com>"
+
+    def test_pqc_sign_verify_roundtrip(self):
+        tsk = Tsk.generate(
+            "PQC <pqc@example.com>",
+            profile=Profile.RFC9580,
+            cipher_suite=CipherSuite.MLDSA65_Ed25519,
+        )
+        data = b"post-quantum signed data"
+        signed = sign(tsk.signer(), data)
+
+        def store(key_ids):
+            return [tsk.extract_certificate()]
+
+        result = verify(signed, store)
+        assert result.bytes == data
+
+    def test_pqc_encrypt_decrypt_roundtrip(self):
+        sender = Tsk.generate(
+            "PQC Sender <s@example.com>",
+            profile=Profile.RFC9580,
+            cipher_suite=CipherSuite.MLDSA65_Ed25519,
+        )
+        receiver = Tsk.generate(
+            "PQC Receiver <r@example.com>",
+            profile=Profile.RFC9580,
+            cipher_suite=CipherSuite.MLDSA65_Ed25519,
+        )
+        content = b"post-quantum encrypted data"
+
+        encrypted = encrypt(
+            signer=sender.signer(),
+            recipients=[receiver.extract_certificate()],
+            bytes=content,
+        )
+
+        def store(key_ids):
+            return [sender.extract_certificate()]
+
+        decrypted = decrypt(
+            decryptor=receiver.decryptor(),
+            bytes=encrypted,
+            store=store,
+        )
+        assert decrypted.bytes == content
+        assert decrypted.valid_sigs[0].certificate == sender.extract_certificate().fingerprint
+
+    def test_pqc_detached_signature(self):
+        tsk = Tsk.generate(
+            "PQC <pqc@example.com>",
+            profile=Profile.RFC9580,
+            cipher_suite=CipherSuite.MLDSA65_Ed25519,
+        )
+        detached = sign(tsk.signer(), b"data", mode=SignatureMode.DETACHED)
+        sig = Sig.from_bytes(detached)
+        assert sig.version == 6
+
+    def test_pqc_requires_rfc9580(self):
+        with pytest.raises(Exception):
+            Tsk.generate(
+                "PQC <pqc@example.com>",
+                cipher_suite=CipherSuite.MLDSA65_Ed25519,
+            )
+
+    def test_pqc_key_algorithm_introspection(self):
+        tsk = Tsk.generate(
+            "PQC <pqc@example.com>",
+            profile=Profile.RFC9580,
+            cipher_suite=CipherSuite.MLDSA65_Ed25519,
+        )
+        pile = PacketPile.from_bytes(bytes(tsk.extract_certificate()))
+        key_algorithms = [
+            p.key_algorithm
+            for p in pile
+            if p.tag in (Tag.PublicKey, Tag.PublicSubkey)
+        ]
+        assert PublicKeyAlgorithm.MLDSA65_Ed25519 in key_algorithms
+        assert PublicKeyAlgorithm.MLKEM768_X25519 in key_algorithms
+
+    def test_pqc_mldsa87_ed448(self):
+        tsk = Tsk.generate(
+            "PQC87 <pqc87@example.com>",
+            profile=Profile.RFC9580,
+            cipher_suite=CipherSuite.MLDSA87_Ed448,
+        )
+        data = b"higher security PQC"
+        signed = sign(tsk.signer(), data)
+
+        def store(key_ids):
+            return [tsk.extract_certificate()]
+
+        result = verify(signed, store)
+        assert result.bytes == data
+
+    def test_pqc_cross_encrypt_classical_to_pqc(self):
+        classical = Tsk.generate(
+            "Classical <classical@example.com>",
+            profile=Profile.RFC9580,
+        )
+        pqc = Tsk.generate(
+            "PQC <pqc@example.com>",
+            profile=Profile.RFC9580,
+            cipher_suite=CipherSuite.MLDSA65_Ed25519,
+        )
+        content = b"cross-algorithm message"
+
+        encrypted = encrypt(
+            signer=classical.signer(),
+            recipients=[pqc.extract_certificate()],
+            bytes=content,
+        )
+
+        def store(key_ids):
+            return [classical.extract_certificate()]
+
+        decrypted = decrypt(
+            decryptor=pqc.decryptor(),
+            bytes=encrypted,
+            store=store,
+        )
+        assert decrypted.bytes == content
+
+
+class TestCipherSuite:
+    def test_generate_rsa4k(self):
+        tsk = Tsk.generate("RSA <rsa@example.com>", cipher_suite=CipherSuite.RSA4k)
+        cert = tsk.extract_certificate()
+        assert len(cert.fingerprint) > 0
+
+    def test_generate_default_cipher_suite(self):
+        tsk = Tsk.generate("Default <default@example.com>")
+        cert = tsk.extract_certificate()
+        assert len(cert.fingerprint) > 0
+
+    def test_all_cipher_suite_variants_exist(self):
+        assert CipherSuite.Cv25519 is not None
+        assert CipherSuite.Cv448 is not None
+        assert CipherSuite.RSA2k is not None
+        assert CipherSuite.RSA3k is not None
+        assert CipherSuite.RSA4k is not None
+        assert CipherSuite.P256 is not None
+        assert CipherSuite.P384 is not None
+        assert CipherSuite.P521 is not None
+        assert CipherSuite.MLDSA65_Ed25519 is not None
+        assert CipherSuite.MLDSA87_Ed448 is not None
 
 
 class TestPacketPile:


### PR DESCRIPTION
* Bump sequoia_openpgp to 2.4(.1) for access to PQC support in sequoia
* Add PQC algorithm variants to enums
* Add a CipherSuite enum and expose it via Cert.generate(cipher_suite=...)

Ignore the commits that are part of https://github.com/wiktor-k/pysequoia/pull/80, they ought to be rebased away once the former merges.