### PR TITLE
BodyFix Packet.body to return only body bytes, add __bytes__

### DIFF
--- a/NEXT.md
+++ b/NEXT.md
@@ -6,16 +6,21 @@ New:
   - `Tsk` now supports `__bytes__` and `__repr__` [#73]
   - `verify` now supports compressed signatures [#77]
   - `Cert.generate` has a new option to control expiration: `validity_seconds` [#75]
+  - `Packet` now supports `__bytes__` to get the full serialized packet [#85]
+
+Fixed:
+  - `Packet.body` now returns just the body bytes without the tag and length header [#85]
 
 Changed:
-  - `Cert.secrets` is now typed as `Tsk` instead of `Any`
+  -
 
 Removed:
-  - 
+  -
 
 [#73]: https://github.com/wiktor-k/pysequoia/pull/73
 [#75]: https://github.com/wiktor-k/pysequoia/pull/75
 [#77]: https://github.com/wiktor-k/pysequoia/pull/77
+[#85]: https://github.com/wiktor-k/pysequoia/pull/85
 
 ### Release checklist:
 ###  [ ] Change version in `Cargo.toml` and `pyproject.toml` and `NEXT.md`

--- a/python/pysequoia/packet.pyi
+++ b/python/pysequoia/packet.pyi
@@ -113,6 +113,10 @@ class Packet:
     data from different packet types (keys, signatures, user IDs, etc.).
     Accessors return `None` when called on the wrong packet type.
     """
+    def __bytes__(self, /) -> bytes:
+        """
+        The full serialized packet bytes (tag, length header, and body).
+        """
     def __repr__(self, /) -> str: ...
     @property
     def body(self, /) -> bytes:

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -4,6 +4,7 @@ use pyo3::prelude::*;
 use sequoia_openpgp::{Packet, PacketPile as SqPacketPile, parse::Parse, serialize::Marshal};
 
 use crate::notation::Notation;
+use crate::runtime_err;
 use crate::types::{DataFormat, HashAlgorithm, KeyFlags, PublicKeyAlgorithm, SignatureType, Tag};
 
 /// A parsed collection of OpenPGP packets.
@@ -101,11 +102,39 @@ impl PyPacket {
         Ok(self.packet.tag().try_into()?)
     }
 
+    /// The full serialized packet bytes (tag, length header, and body).
+    pub fn __bytes__(&self) -> PyResult<Vec<u8>> {
+        let mut buf = Vec::new();
+        Marshal::serialize(&self.packet, &mut buf)?;
+        Ok(buf)
+    }
+
     /// The raw body bytes of this packet (without the tag and length header).
     #[getter]
     pub fn body(&self) -> PyResult<Cow<'_, [u8]>> {
         let mut buf = Vec::new();
-        Marshal::serialize(&self.packet, &mut buf)?;
+        match &self.packet {
+            Packet::PublicKey(p) => Marshal::serialize(p, &mut buf)?,
+            Packet::PublicSubkey(p) => Marshal::serialize(p, &mut buf)?,
+            Packet::SecretKey(p) => Marshal::serialize(p, &mut buf)?,
+            Packet::SecretSubkey(p) => Marshal::serialize(p, &mut buf)?,
+            Packet::Signature(p) => Marshal::serialize(p, &mut buf)?,
+            Packet::OnePassSig(p) => Marshal::serialize(p, &mut buf)?,
+            Packet::UserID(p) => Marshal::serialize(p, &mut buf)?,
+            Packet::UserAttribute(p) => Marshal::serialize(p, &mut buf)?,
+            Packet::Literal(p) => Marshal::serialize(p, &mut buf)?,
+            Packet::CompressedData(p) => Marshal::serialize(p, &mut buf)?,
+            Packet::PKESK(p) => Marshal::serialize(p, &mut buf)?,
+            Packet::SKESK(p) => Marshal::serialize(p, &mut buf)?,
+            Packet::SEIP(p) => Marshal::serialize(p, &mut buf)?,
+            Packet::Unknown(p) => Marshal::serialize(p, &mut buf)?,
+            Packet::Marker(p) => Marshal::serialize(p, &mut buf)?,
+            Packet::Trust(p) => Marshal::serialize(p, &mut buf)?,
+            #[expect(deprecated)]
+            Packet::MDC(p) => Marshal::serialize(p, &mut buf)?,
+            Packet::Padding(p) => Marshal::serialize(p, &mut buf)?,
+            _ => Err(runtime_err("Unsupported packet type"))?,
+        }
         Ok(buf.into())
     }
 

--- a/tests/test_pysequoia.py
+++ b/tests/test_pysequoia.py
@@ -497,7 +497,24 @@ class TestPacketPile:
         cert = Cert.generate("Test <test@example.com>")
         packet = list(PacketPile.from_bytes(bytes(cert)))[0]
         assert packet.tag == Tag.PublicKey
-        assert len(packet.body) > 0
+        body = packet.body
+        assert len(body) > 0
+        assert body[0] in (4, 6)
+
+    def test_packet_body_excludes_header(self):
+        cert = Cert.generate("Test <test@example.com>")
+        for packet in PacketPile.from_bytes(bytes(cert)):
+            body = packet.body
+            full = bytes(packet)
+            assert len(full) > len(body)
+            assert full[-len(body):] == body
+
+    def test_packet_bytes_roundtrip(self):
+        cert = Cert.generate("Test <test@example.com>")
+        packets = list(PacketPile.from_bytes(bytes(cert)))
+        reassembled = b"".join(bytes(p) for p in packets)
+        reparsed = Cert.from_bytes(reassembled)
+        assert reparsed.fingerprint == cert.fingerprint
 
 
 class TestArmor:


### PR DESCRIPTION
Packet.body was calling Marshal::serialize on the Packet enum, which
includes the CTB tag byte and body length header, contradicting the
documented behavior.

Dispatch to each variant's inner type serialize instead, which writes
only the body. Add __bytes__() to provide the full serialized packet.

Needs https://github.com/wiktor-k/pysequoia/pull/80 merged first - will rebase later.